### PR TITLE
adjust buildscript to work inside wsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+MarlinFirmware
+build

--- a/build-marlin.sh
+++ b/build-marlin.sh
@@ -1,15 +1,18 @@
-#!/bin/sh
+#!/bin/bash
+
+# set to true to ignore updating marlin to latest version
+UPDATE_SKIP=
 
 # Check if the docker image is older than a day, skip building if you already built the image today
 today=$(date '+%Y-%m-%d')
 image_date=$(docker inspect --format "{{json .Created}}" local/platformio | grep -Eo '[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}')
 
-if [ $today != $image_date ]; then
+if [[ ${today} != ${image_date} ]]; then
   docker build . -t local/platformio
 fi
 
 # Ask if wish to update MarlinFirmware to the latest release
-if [ -z $UPDATE_SKIP ]; then
+if [[ -z ${UPDATE_SKIP} ]]; then
   read -r -p "Do you want to update MarlinFirmware to latest release? [y/N] " response
   case "$response" in
       [yY][eE][sS]|[yY])
@@ -27,22 +30,22 @@ CONFIG_FILES=$(find CustomConfiguration -name '*.h' -exec basename {} .h \;)
 
 # Remove configuration files if they exist in Marlin folder
 while IFS= read -r line; do
-    rm -f $(PWD)/MarlinFirmware/$line.h
+    rm -f $(pwd)/MarlinFirmware/${line}.h
 done <<< "$CONFIG_FILES"
 
 # Copy custom configuration files to Marlin folder, symlink will not work as they wont be mounted in docker image
 while IFS= read -r line; do
-  cp $(PWD)/CustomConfiguration/$line.h $(PWD)/MarlinFirmware/Marlin/$line.h
+  cp $(pwd)/CustomConfiguration/${line}.h $(pwd)/MarlinFirmware/Marlin/${line}.h
 done <<< "$CONFIG_FILES"
 
 # Change the default board with value in board file. sed is borked on MacOS so the rm/mv is a ugly workaround
-sed "s/default_envs = .*/default_envs = $(cat $(PWD)/CustomConfiguration/board)/" $(PWD)/MarlinFirmware/platformio.ini > $(PWD)/MarlinFirmware/platformio.ini_new
-rm $(PWD)/MarlinFirmware/platformio.ini
-mv $(PWD)/MarlinFirmware/platformio.ini_new $(PWD)/MarlinFirmware/platformio.ini
+sed "s/default_envs = .*/default_envs = $(cat $(pwd)/CustomConfiguration/board)/" $(pwd)/MarlinFirmware/platformio.ini > $(pwd)/MarlinFirmware/platformio.ini_new
+rm $(pwd)/MarlinFirmware/platformio.ini
+mv $(pwd)/MarlinFirmware/platformio.ini_new $(pwd)/MarlinFirmware/platformio.ini
 
 # Build the Marlin firmware
 docker run --rm -it \
-  -v $(PWD)/MarlinFirmware:/home/platformio/MarlinFirmware \
+  -v $(pwd)/MarlinFirmware:/home/platformio/MarlinFirmware \
   -w /home/platformio/MarlinFirmware \
   local/platformio platformio run
 


### PR DESCRIPTION
First and foremost: thanks for this idea / repo, was exactly what I was trying to "find out on my own" after getting my ender 3 back up and running to streamline firmware building.

Hopefully my changes don't break MacOS compatibility.

My WSL (Ubuntu 18.04) shell defaults to dash (/bin/sh is a symlink to /bin/dash) and not bash so the buildscript didn't work. Also my IDE complained about a couple of code-style issues but hopefully nothing major that breaks on MacOS, maybe you can double-check if it still works.

Also added IDE config and submodule to gitignore so they don't clutter up the commits / accidentally get commited

Oh and last but not least: It's Hacktober, mind marking my PR as "hacktoberfest-accepted" or adding the topic "hacktoberfest" to your project? maybe more contributors will follow :)